### PR TITLE
Remove xregexp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "gensequence": "^3.1.1",
-        "mnemonist": "^0.38.3",
-        "xregexp": "^5.1.0"
+        "mnemonist": "^0.38.3"
       },
       "devDependencies": {
         "@types/jest": "^27.0.2",
@@ -577,18 +576,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.4.tgz",
-      "integrity": "sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==",
-      "dependencies": {
-        "core-js-pure": "^3.16.0",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1893,16 +1880,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.1.tgz",
-      "integrity": "sha512-kmW/k8MaSuqpvA1xm2l3TVlBuvW+XBkcaOroFUpO3D4lsTGQWBTb/tBDCf/PNkkPLrwgrkQRIYNPB0CeqGJWGQ==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cross-spawn": {
@@ -4538,11 +4515,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -5317,14 +5289,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xregexp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.0.tgz",
-      "integrity": "sha512-PynwUWtXnSZr8tpQlDPMZfPTyv78EYuA4oI959ukxcQ0a9O/lvndLVKy5wpImzzA26eMxpZmnAXJYiQA13AtWA==",
-      "dependencies": {
-        "@babel/runtime-corejs3": "^7.14.9"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5793,15 +5757,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
-    "@babel/runtime-corejs3": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.4.tgz",
-      "integrity": "sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==",
-      "requires": {
-        "core-js-pure": "^3.16.0",
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -6795,11 +6750,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "core-js-pure": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.1.tgz",
-      "integrity": "sha512-kmW/k8MaSuqpvA1xm2l3TVlBuvW+XBkcaOroFUpO3D4lsTGQWBTb/tBDCf/PNkkPLrwgrkQRIYNPB0CeqGJWGQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -8781,11 +8731,6 @@
         "resolve": "^1.1.6"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -9342,14 +9287,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xregexp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.0.tgz",
-      "integrity": "sha512-PynwUWtXnSZr8tpQlDPMZfPTyv78EYuA4oI959ukxcQ0a9O/lvndLVKy5wpImzzA26eMxpZmnAXJYiQA13AtWA==",
-      "requires": {
-        "@babel/runtime-corejs3": "^7.14.9"
-      }
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
   },
   "dependencies": {
     "gensequence": "^3.1.1",
-    "mnemonist": "^0.38.3",
-    "xregexp": "^5.1.0"
+    "mnemonist": "^0.38.3"
   },
   "files": [
     "LICENSE",

--- a/src/string-utils.ts
+++ b/src/string-utils.ts
@@ -1,11 +1,10 @@
 import { genSequence } from 'gensequence';
-import XRegExp from 'xregexp';
 
-const WHITESPACE_REGEX: RegExp = XRegExp('^\\p{Z}+$');
-const PUNCT_REGEX: RegExp = XRegExp('^\\p{P}+$');
-const SYMBOL_REGEX: RegExp = XRegExp('^\\p{S}+$');
-const CONTROL_REGEX: RegExp = XRegExp('^\\p{Cc}+$');
-const LOWER_REGEX: RegExp = XRegExp('^\\p{Ll}+$');
+const WHITESPACE_REGEX = /^\p{Z}+$/u;
+const PUNCT_REGEX = /^\p{P}+$/u;
+const SYMBOL_REGEX = /^\p{S}+$/u;
+const CONTROL_REGEX = /^\p{Cc}+$/u;
+const LOWER_REGEX = /^\p{Ll}+$/u;
 const SENTENCE_TERMINALS: Set<string> = new Set<string>([
   '.',
   '!',

--- a/src/tokenization/latin-word-detokenizer.ts
+++ b/src/tokenization/latin-word-detokenizer.ts
@@ -1,4 +1,3 @@
-import XRegExp from 'xregexp';
 import { isPunctuation } from '../string-utils';
 import { DetokenizeOperation, StringDetokenizer } from './string-detokenizer';
 
@@ -29,7 +28,7 @@ const QUOTATION_MARKS = new Map<string, QuoteType>([
   ['›', QuoteType.SingleAngle],
 ]);
 
-const MERGE_RIGHT_REGEX: RegExp = XRegExp('^\\p{Sc}|[([{¿¡<]$');
+const MERGE_RIGHT_REGEX = /^\p{Sc}|[([{¿¡<]$/u;
 
 export class LatinWordDetokenizer extends StringDetokenizer {
   protected createContext(): string[] {

--- a/src/tokenization/latin-word-tokenizer.ts
+++ b/src/tokenization/latin-word-tokenizer.ts
@@ -1,11 +1,9 @@
-import XRegExp from 'xregexp';
-
 import { createRange, Range } from '../annotations/range';
 import { isControl, isPunctuation, isSymbol } from '../string-utils';
 import { WhitespaceTokenizer } from './whitespace-tokenizer';
 
-const INNER_WORD_PUNCT_REGEX: RegExp = XRegExp("^[&\\-.:=,?@\xAD\xB7\u2010\u2011\u2019\u2027]|['_]+");
-const URL_REGEX: RegExp = XRegExp('^(?:[\\w-]+://?|www[.])[^\\s()<>]+(?:[\\w\\d]+|(?:[^\\p{P}\\s]|/))', 'i');
+const INNER_WORD_PUNCT_REGEX = /^[&\-.:=,?@\xAD\xB7\u2010\u2011\u2019\u2027]|['_]+/u;
+const URL_REGEX = /^(?:[\w-]+:\/\/?|www[.])[^\s()<>]+(?:[\w\d]+|(?:[^\p{P}\s]|\/))/iu;
 
 export class TokenizeContext {
   index = 0;

--- a/src/translation/phrase-translation-suggester.ts
+++ b/src/translation/phrase-translation-suggester.ts
@@ -1,11 +1,9 @@
-import XRegExp from 'xregexp';
-
 import { TranslationResult } from './translation-result';
 import { TranslationSources } from './translation-sources';
 import { TranslationSuggester } from './translation-suggester';
 import { TranslationSuggestion } from './translation-suggestion';
 
-const ALL_PUNCT_REGEXP = XRegExp('^\\p{P}*$');
+const ALL_PUNCT_REGEXP = /^\p{P}*$/u;
 
 function computeKmpTable(newSuggestion: readonly string[]): number[] {
   const table = new Array<number>(newSuggestion.length);


### PR DESCRIPTION
According to caniuse, the Unicode modifier on JavaScript regexes is [already well supported](https://caniuse.com/mdn-javascript_builtins_regexp_unicode) in more browsers than Scripture Forge supports. xregexp is fairly large and currently constitutes a little over 5% of our total bundle, and is only required due to being a dependency of machine.js.